### PR TITLE
Fix issue with `descendants(mtg, symbol=:Leaf)`

### DIFF
--- a/src/compute_MTG/check_filters.jl
+++ b/src/compute_MTG/check_filters.jl
@@ -31,6 +31,7 @@ end
 end
 
 @inline normalize_symbol_allowed(filters::Nothing) = nothing
+@inline normalize_symbol_allowed(filter) = (normalize_symbol_filter(filter),)
 @inline function normalize_symbol_allowed(filters::T) where {T<:Union{Tuple,AbstractArray}}
     map(normalize_symbol_filter, filters)
 end

--- a/test/test-descendants.jl
+++ b/test/test-descendants.jl
@@ -58,6 +58,8 @@
       @test descendants(mtg) == traverse(mtg[1], x -> x)
       @test descendants(mtg, self=true) == traverse(mtg, x -> x)
       @test descendants(get_node(mtg, 6), self=true) == [get_node(mtg, 6), get_node(mtg, 7)]
+      mtg[:symbols] = SubString("Leaf", 1, 4)
+      @test descendants(mtg, symbol=:Leaf) == [get_node(mtg, 5), get_node(mtg, 7)]
 
       out_nodes = typeof(mtg)[]
       @test descendants!(out_nodes, mtg) == traverse(mtg[1], x -> x)


### PR DESCRIPTION
`normalize_symbol_allowed` didn't accept singleton values except for `nothing`. Fixed this.